### PR TITLE
Follow JS logical operator precedence.

### DIFF
--- a/ts/parse.ts
+++ b/ts/parse.ts
@@ -70,19 +70,19 @@ let cmp: P.Parser<Expr> = P.lazy(() =>
             }, lhs);
         })));
 
-let or: P.Parser<Expr> = P.lazy(() =>
-    cmp.chain(lhs =>
-        P.seq(operator('||'), cmp).many().map((opNumArr) => {
-            return opNumArr.reduce((acc, currVal) => a.operator('||', acc, currVal[1]), lhs);
-        })));
-
 let and: P.Parser<Expr> = P.lazy(() =>
-    or.chain(lhs =>
-        P.seq(operator('&&'), or).many().map((opNumArr) => {
+    cmp.chain(lhs =>
+        P.seq(operator('&&'), cmp).many().map((opNumArr) => {
             return opNumArr.reduce((acc, currVal) => a.operator('&&', acc, currVal[1]), lhs);
         })));
 
-let expr = and;
+let or: P.Parser<Expr> = P.lazy(() =>
+    and.chain(lhs =>
+        P.seq(operator('||'), and).many().map((opNumArr) => {
+            return opNumArr.reduce((acc, currVal) => a.operator('||', acc, currVal[1]), lhs);
+        })));
+
+let expr = or;
 
 let stmt: P.Parser<Stmt> = P.lazy(() =>
     token('let')

--- a/ts/parsetc.test.ts
+++ b/ts/parsetc.test.ts
@@ -50,9 +50,8 @@ test('logical precedence', () => {
     let r = parseProgram('let x = true || false && true;');
     expect(r.kind).toBe('ok');
     expect(r.unsafeGet()).toEqual([
-        a.let_('x', a.operator('&&',
-            a.operator('||', a.bool(true), a.bool(false)),
-            a.bool(true)))]);
+        a.let_('x', a.operator('||', a.bool(true),
+            a.operator('&&', a.bool(false), a.bool(true))))]);
 });
 
 test('comparison', () => {


### PR DESCRIPTION
Parser was doing the opposite of [JS](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#Table) in regards to the precedence of `&&` and `||`. 